### PR TITLE
Add Dependabot configuration for npm updates

### DIFF
--- a/dependabot.yaml
+++ b/dependabot.yaml
@@ -1,0 +1,12 @@
+# .github/dependabot.yml
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]   # batch the safe stuff into one PR
+    # Major bumps come as their own PRs so you review breaking changes deliberately


### PR DESCRIPTION
# .github/dependabot.yml
version: 2
updates:
  - package-ecosystem: "npm" directory: "/" schedule: interval: "weekly" open-pull-requests-limit: 5 groups: minor-and-patch:
        update-types: ["minor", "patch"]   # batch the safe stuff into one PR
    # Major bumps come as their own PRs so you review breaking changes deliberately



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->